### PR TITLE
Fix parameters in security scan stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
          }
          stage('Security Scan') {
               steps { 
-                 aquaMicroscanner imageName: 'alpine:latest', notCompleted: 'exit 1', onDisallowed: 'fail'
+                 aquaMicroscanner imageName: 'alpine:latest', notCompliesCmd: 'exit 1', onDisallowed: 'fail', outputFormat: 'html'
               }
          }         
          stage('Upload to AWS') {


### PR DESCRIPTION
- Replaces the unrecognized `notCompleted` parameter by `notCompliesCmd`
- Adds required parameter `outputFormat` with the default value to `html` 
Related issue: #4 